### PR TITLE
Add support for custom datatype size

### DIFF
--- a/lsl-lib/private/library/test.rkt
+++ b/lsl-lib/private/library/test.rkt
@@ -233,17 +233,13 @@
           (list (make-check-params (list name (~? n))))
           (λ () (parameterize ([current-logs #f]) thk-body))))]))
 
-;; TODO: parameterize by scaling?
-(define (scale-fuel x)
-  (if (zero? x) x (inexact->exact (ceiling (log x)))))
-
 (define-check (check-contract val name n)
   (define ctc (proxy->contract val))
   (if ctc
       (for ([fuel (in-range 2 (+ n 2))])
         (do-check-contract
          ctc val name
-         (λ (ctc) (send ctc generate (scale-fuel fuel)))))
+         (λ (ctc) (send ctc generate fuel))))
       (fail-check (format "unknown contract for ~a" name))))
 
 (define (do-check-contract ctc val name contract->value)

--- a/lsl-lib/private/library/test.rkt
+++ b/lsl-lib/private/library/test.rkt
@@ -224,22 +224,35 @@
 (define ($contracted? p)
   (if (proxy->contract p) #t #f))
 
+(define default-size 
+    (lambda (fuel) fuel))
+
 (define-syntax ($check-contract stx)
   (syntax-parse stx
-    [(_ name:id (~optional n:number #:defaults ([n #'100])))
-     #:with thk-body (syntax/loc stx (check-contract name 'name n))
+    [(_ name:id 
+        (~optional n:number #:defaults ([n #'100]))
+        (~optional (~seq #:size size:expr) #:defaults ([size #'default-size])))
+     #:with thk-body (syntax/loc stx (check-contract name 'name n size))
      (push-form!
       #'(with-default-check-info*
           (list (make-check-params (list name (~? n))))
           (λ () (parameterize ([current-logs #f]) thk-body))))]))
 
-(define-check (check-contract val name n)
+(define (scale-fuel size n)
+  (if (procedure? size)
+    (size n)
+    (if (number? size)
+      size
+      (fail-check "Expected procedure or number for size parameter"))))
+
+
+(define-check (check-contract val name n size)
   (define ctc (proxy->contract val))
   (if ctc
       (for ([fuel (in-range 2 (+ n 2))])
         (do-check-contract
          ctc val name
-         (λ (ctc) (send ctc generate fuel))))
+         (λ (ctc) (send ctc generate (scale-fuel size fuel)))))
       (fail-check (format "unknown contract for ~a" name))))
 
 (define (do-check-contract ctc val name contract->value)


### PR DESCRIPTION
Previously, LSL used `scale-fuel` to take the log of the current fuel to serve as a bound for generating unbounded datatypes, such as Integers.  This hard-coded default was somewhat restrictive for class, as it made it difficult to demonstrate how we can catch incorrect functions. 

This PR adds support for custom fuel scaling via the following syntax:
```
(check-contract foo 200 #:size size-pol)
```
As before, the number after `foo` is the number of tests to run. But now, `size-pol` dictates the bound for unbounded contracts.  This policy `size-pol` can either be a number or a lambda, which determines the bound as a function of the loop counter. Thus, to set the bound equal to 100 (still with 200 tests) you can do 
```
(check-contract foo 200 #:size 100)
```
and to recover the previous behavior, you can do (if we had log in LSL):
```
(check-contract foo 200 #:size (lambda (n) (log n)))
```

The default behavior, when we do `(check-contract foo 200)`, is 
```
(check-contract foo 200 #:size (lambda (n) n))
```
(i.e., the bound for generating integers is the same as the test counter).