### PR TITLE
Better errors for invalid contracts in signatures

### DIFF
--- a/lsl-lib/private/library/test.rkt
+++ b/lsl-lib/private/library/test.rkt
@@ -270,10 +270,6 @@
   (define stats (current-pbt-stats))
   (when stats (current-pbt-stats (cons ht stats))))
 
-(define (limited-error? exn)
-  (and (exn:fail? exn)
-       (not (exn:fail:gave-up? exn))))
-
 (define (do-check-contract ctc val name time contract->value)
   (define base-hash
     (hash 'type "test_case"
@@ -292,7 +288,7 @@
     (λ () (raise exn)))
   (with-handlers ([exn:fail:gave-up? handle-gave-up]
                   [exn:fail:invalid? handle-invalid])
-    (match (with-handlers ([limited-error?
+    (match (with-handlers ([exn:fail:invalid-signature-contract?
                           (λ (e)
                              (improper-contract-error name
                                                       (exn-message e)))])

--- a/lsl-lib/private/library/test.rkt
+++ b/lsl-lib/private/library/test.rkt
@@ -270,6 +270,10 @@
   (define stats (current-pbt-stats))
   (when stats (current-pbt-stats (cons ht stats))))
 
+(define (limited-error? exn)
+  (and (exn:fail? exn)
+       (not (exn:fail:gave-up? exn))))
+
 (define (do-check-contract ctc val name time contract->value)
   (define base-hash
     (hash 'type "test_case"
@@ -288,7 +292,7 @@
     (λ () (raise exn)))
   (with-handlers ([exn:fail:gave-up? handle-gave-up]
                   [exn:fail:invalid? handle-invalid])
-    (match (with-handlers ([exn:fail?
+    (match (with-handlers ([limited-error?
                           (λ (e)
                              (improper-contract-error name
                                                       (exn-message e)))])

--- a/lsl-lib/private/syntax/compile.rkt
+++ b/lsl-lib/private/syntax/compile.rkt
@@ -85,8 +85,12 @@
               [checker chk]
               [generator gen]
               [shrinker shk]
-              [feature feat]) 
-              (error "Invalid contract:" chk))]
+              [feature feat])
+             (raise
+              (exn:fail:invalid-signature-contract
+               (format "Invalid contract: ~a" chk)
+               (current-continuation-marks)
+               (list (syntax-property quoted-stx 'unexpanded)))))]
       [(Function (arguments [x fvs a] ...)
                  (result r)
                  (raises e:struct-id ...))

--- a/lsl-lib/private/syntax/compile.rkt
+++ b/lsl-lib/private/syntax/compile.rkt
@@ -79,12 +79,14 @@
                   (generate gen)
                   (shrink shk)
                   (feature feat))
-       #'(new immediate-contract%
+       #'(if (procedure? chk)
+             (new immediate-contract%
               [syntax quoted-stx]
               [checker chk]
               [generator gen]
               [shrinker shk]
-              [feature feat])]
+              [feature feat]) 
+              (error "Invalid contract:" chk))]
       [(Function (arguments [x fvs a] ...)
                  (result r)
                  (raises e:struct-id ...))

--- a/lsl-lib/private/util.rkt
+++ b/lsl-lib/private/util.rkt
@@ -20,6 +20,7 @@
                      contract-table-set!)
          (struct-out base-seal)
          (struct-out exn:fail:gave-up)
+         (struct-out exn:fail:invalid-signature-contract)
          (struct-out exn:fail:invalid)
          give-up
          current-logs
@@ -43,6 +44,7 @@
 ;; exns
 
 (struct exn:fail:gave-up exn:fail:syntax ())
+(struct exn:fail:invalid-signature-contract exn:fail:syntax ())
 (struct exn:fail:invalid exn:fail:syntax (witness))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/lsl/tests/function.rkt
+++ b/lsl/tests/function.rkt
@@ -204,10 +204,12 @@
   #:x (run* (: f (-> #t Integer))
             (define (f x) 42)
             (check-contract f))
-  "Problem in signature for f"
+  "Problem in signature for f
+  Invalid contract: #t"
 
   #:x (run* (: f (-> Integer #t))
             (define (f x) 42)
             (check-contract f))
-  "Problem in signature for f"
+  "Problem in signature for f
+  Invalid contract: #t"
   ))

--- a/lsl/tests/function.rkt
+++ b/lsl/tests/function.rkt
@@ -200,4 +200,14 @@
             (define (f x) (if (empty? x) (raise (make-ok)) ""))
             (check-contract f))
   "counterexample: (f '("
+
+  #:x (run* (: f (-> #t Integer))
+            (define (f x) 42)
+            (check-contract f))
+  "Problem in signature for f"
+
+  #:x (run* (: f (-> Integer #t))
+            (define (f x) 42)
+            (check-contract f))
+  "Problem in signature for f"
   ))


### PR DESCRIPTION
To be honest this fix feels a little scuffed, but it seems to work perfectly fine, just had to deal with the issue of exceptions getting caught and wrapped in counterexample cases in test.rkt. As a result, just made it recognize the specific error and prevent the overlap of the two different kinds of errors, though I'll probably look for a nicer fix in the near future.